### PR TITLE
Use Clang C++ mangling for WASM targets

### DIFF
--- a/source/bindbc/common/codegen.d
+++ b/source/bindbc/common/codegen.d
@@ -421,6 +421,7 @@ enum mangleofCppDefaultCtor = (string[] syms) nothrow pure @safe{
 		version(CppRuntime_Clang)    return true;
 		else version(CppRuntime_Gcc) return true;
 		else version(Android)        return true;
+		else version(WebAssembly)    return true;
 		else return false;
 	}()){
 		string ret = "_ZN";


### PR DESCRIPTION
Since the only WASM C++ compiler that I'm aware of would be the one implemented for Clang under LLVM, this PR includes an additional `version(WebAssembly)` for that mangling scheme.

Previously, compilation of bindbc libraries did not work when targeted to WASM due to this single lack of handling (going to the final `static assert(0, ...)`). With this, as per what I've tested, `bindbc-sdl` works when targeting to `wasm32-unknown-unknown-wasi` under ldc2 as a static binding in conjunction with emscripten.

## Example

```d
// main.d
extern (C):

import bindbc.sdl;
import core.stdc.math;

__gshared {
	SDL_Window* window;
	SDL_Renderer* renderer;
}

void myDMain() {
	version (BindSDL_Static) {
	}
	else {
		if (loadSDL() != sdlSupport) {
			assert(false);
		}
	}

	// Unfortunately, core.stdc.stdio isn't usable.
	SDL_Log("Hello from D!");

	SDL_Init(SDL_INIT_VIDEO);
	SDL_SetHint(SDL_HINT_EMSCRIPTEN_KEYBOARD_ELEMENT, "#canvas");

	SDL_GL_SetAttribute(SDL_GL_CONTEXT_PROFILE_MASK, SDL_GL_CONTEXT_PROFILE_ES);
	SDL_GL_SetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, 3);
	SDL_GL_SetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, 0);

	window = SDL_CreateWindow(
		"Boilerplate",
		SDL_WINDOWPOS_CENTERED,
		SDL_WINDOWPOS_CENTERED,
		800,
		600,
		SDL_WINDOW_SHOWN
	);
	renderer = SDL_CreateRenderer(window, -1, SDL_RENDERER_ACCELERATED);
}

int myDLoop() {
	SDL_Event event = void;
	while (SDL_PollEvent(&event) != 0) {
		if (event.type == SDL_QUIT) {
			return 1;
		}
	}

	// Flashes
	ubyte val = cast(ubyte)(sin(SDL_GetTicks() / 100.0) * 127 + 128);
	SDL_SetRenderDrawColor(renderer, val, val, val, 255);
	SDL_RenderClear(renderer);

	SDL_RenderPresent(renderer);

	return 0;
}

void myDEnd() {
	SDL_DestroyRenderer(renderer);
	SDL_DestroyWindow(window);
	SDL_Quit();
}
```

```c
// main.c
#include <stdio.h>

#ifdef __EMSCRIPTEN__
#include <emscripten.h>
#include <emscripten/html5.h>
#endif

extern void myDMain(void);
extern int myDLoop(void);
extern void myDEnd(void);

void emLoop(void) {
    myDLoop();
}

int main() {
    printf("Hello from Emscripten!\n");

    myDMain();

#ifdef __EMSCRIPTEN__
    emscripten_set_main_loop(&emLoop, 0, 1);
#else
    while (myDLoop() == 0);
#endif

    myDEnd();
}
```

```sh
#!/bin/bash
dub build --combined --compiler=ldc2 --arch=wasm32-unknown-unknown-wasi
emcc main.c -L. -ldsdltest -sUSE_SDL=2 -sFULL_ES3 -o index.html
```

## Screenshot

![image](https://github.com/user-attachments/assets/24e7eee6-4129-4fec-9b1c-6ee057f1ab1b)
